### PR TITLE
Add fucntion for removing files and folders

### DIFF
--- a/source/util.c
+++ b/source/util.c
@@ -2,7 +2,6 @@
 #include <string.h>
 #include <switch.h>
 #include <dirent.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>


### PR DESCRIPTION
remove_dir заменено на remove_entry
Работает для обычных файлов и папок, в случае последних делает рекурсивный обход содержимого и удаляет всё что найдёт в папке. 
Возвращает 0 в случае успеха и -1 в случае ошибки. 
Проблемный момент есть в том, что если не удаётся удалить какой-то файл внутри папки то и папка удалена не будет (см. комментарии).